### PR TITLE
Added Translation to hr/auth.php

### DIFF
--- a/.idea/vagrant.xml
+++ b/.idea/vagrant.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VagrantProjectSettings">
-    <option name="instanceFolder" value="" />
-    <option name="provider" value="" />
-  </component>
-</project>

--- a/.idea/vagrant.xml
+++ b/.idea/vagrant.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VagrantProjectSettings">
+    <option name="instanceFolder" value="" />
+    <option name="provider" value="" />
+  </component>
+</project>

--- a/hr/auth.php
+++ b/hr/auth.php
@@ -11,5 +11,5 @@ return [
     |
     */
     'failed' => 'Ovi podaci ne odgovaraju našima.',
-    'throttle' => 'Previše pogušaja prijave. Molim Vas pokušajte ponovno za :seconds sekundi.',
+    'throttle' => 'Previše pokušaja prijave. Molim Vas pokušajte ponovno za :seconds sekundi.',
 ];

--- a/hr/auth.php
+++ b/hr/auth.php
@@ -10,6 +10,6 @@ return [
     | these language lines according to your application's requirements.
     |
     */
-    'failed' => 'These credentials do not match our records.',
-    'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
+    'failed' => 'Ovi podaci ne odgovaraju našima.',
+    'throttle' => 'Previše pogušaja prijave. Molim Vas pokušajte ponovno za :seconds sekundi.',
 ];

--- a/hr/auth.php
+++ b/hr/auth.php
@@ -10,6 +10,6 @@ return [
     | these language lines according to your application's requirements.
     |
     */
-    'failed' => 'Ovi podaci ne odgovaraju našima.',
-    'throttle' => 'Previše pogušaja prijave. Molim Vas pokušajte ponovno za :seconds sekundi.',
+    'failed' => 'These credentials do not match our records.',
+    'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
 ];


### PR DESCRIPTION
This correction added a correct Croatian translation
instead of the english ones that were in the auth.php script.
Users of this code will therefore not have to change/modify
these manually as they are already correct.
This prevents from showing unwanted translations and
enhances the user experience.