### PR TITLE
Corrected link to en translations for Laravel 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ How can I add a language in this project ?
 * fork this repository
 * create a directory with the short name of the language (ex: fr for French) from ISO-639-1 ( see [Wikipedia](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) )
 * copy this three files of the english version with your translate
-    * for [Laravel](https://github.com/laravel/laravel/tree/master/app/lang/en)
+    * for [Laravel](https://github.com/laravel/laravel/tree/master/resources/lang/en)
 * add a pull request with the name of the language
 
 


### PR DESCRIPTION
Translations moved from app to resources in Laravel 5