### PR TITLE
Correct a wrong word

### DIFF
--- a/fr/auth.php
+++ b/fr/auth.php
@@ -10,6 +10,6 @@ return [
     | these language lines according to your application's requirements.
     |
     */
-    'failed' => 'Ces certificats ne correspondent pas à nos enregistrements',
+    'failed' => 'Ces identifiants ne correspondent pas à nos enregistrements',
     'throttle' => 'Trop de tentatives de connexion. Veuillez essayer de nouveau dans :seconds secondes.',
 ];


### PR DESCRIPTION
Hi,

"identifiants" is the correct word for this situation.