### PR TITLE
Change the spanish password reminder sent language line for a more readable

### DIFF
--- a/es/passwords.php
+++ b/es/passwords.php
@@ -15,7 +15,7 @@ return [
 
     'password' => 'Las contraseñas deben coincidir y contener al menos 6 caracteres',
     'reset'    => '¡Tu contraseña ha sido restablecida!',
-    'sent'     => '¡Recordatorio de contraseña enviado!',
+    'sent'     => '¡Te hemos enviado por correo el enlace para restablecer tu contraseña!',
     'token'    => 'El token de recuperación de contraseña es inválido.',
     'user'     => 'No podemos encontrar ningún usuario con ese correo electrónico.',
 


### PR DESCRIPTION
Hi,

I would like to contribute with a better spanish language line for password.sent.

I think that the current spanish translation for this line is not accurate and lacks of some detail and context.

English original line states:

"We have e-mailed your password reset link!"

It says that an email was sent with a password reset link, this makes sense to the user viewing this message.

The current spanish translation in english states:

"Password reminder sent!"

It lacks of context and makes me feel like i'm interacting with a robot.

The proposed line in spanish makes the user feel like a person is in the other side. :)

Thanks!