### PR TITLE
more common dutch

### DIFF
--- a/src/nl/auth.php
+++ b/src/nl/auth.php
@@ -14,6 +14,6 @@ return [
     */
 
     'failed'   => 'Deze combinatie van e-mailadres en wachtwoord is niet geldig.',
-    'throttle' => 'Teveel gefaalde login pogingen. Probeer het over :seconds seconden nogmaals.',
+    'throttle' => 'Teveel mislukte login pogingen. Probeer het over :seconds seconden nogmaals.',
 
 ];


### PR DESCRIPTION
'Gefaalde' is not a common word for failed in internet/website language for Dutch 'mislukte' is better