### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,34 +7,38 @@ In this repository, you can find the lang files for the framework PHP, [Laravel 
 ## Install
 
 #### Via Composer
- * For Laravel 5.* : run ```composer require caouecs/laravel-lang:~3.0``` in your project folder
- * For Laravel 5 : run ```composer require caouecs/laravel4-lang:~2.0``` in your project folder
- * For Laravel 4 : run ```composer require caouecs/laravel4-lang:~1.0``` in your project folder
- * Files of languages are in "vendor/caouecs/laravel-lang" directory
- * Copy the folders of languages that you want, in *app/lang* (*resources/lang* in laravel 5) folder of your application Laravel
+* For Laravel 5.* : run `composer require caouecs/laravel-lang:~3.0` in your project folder
+* For Laravel 5 : run `composer require caouecs/laravel4-lang:~2.0` in your project folder
+* For Laravel 4 : run `composer require caouecs/laravel4-lang:~1.0` in your project folder
+* Files of languages are in "vendor/caouecs/laravel-lang" directory
+* Copy the folders of languages that you want, in the *resources/lang* folder of your Laravel application (*app/lang* in Laravel 4).
 
 #### Via GitHub
 
- * Clone the [GitHub repository](https://github.com/caouecs/laravel-lang/) : *git clone https://github.com/caouecs/Laravel-lang.git*
- * Or download the [zip file](https://github.com/caouecs/laravel-lang/archive/master.zip)
- * Choose the branch:
+* Clone the [GitHub repository](https://github.com/caouecs/laravel-lang/) : *git clone https://github.com/caouecs/Laravel-lang.git*
+* Or download the [zip file](https://github.com/caouecs/laravel-lang/archive/master.zip)
+* Choose the branch:
     * `laravel4` for Laravel4 project
     * `master` for Laravel5 project
- * Copy the folders of languages that you want, in *app/lang* folder of your application Laravel
+* Copy the folders of languages that you want, in *resources/lang* folder of your Laravel application (*app/lang* in Laravel 4).
 
 #### Via SVN
 
 Run this in your project directory:
 
-```
+```sh
+# Laravel 5:
 svn export https://github.com/caouecs/Laravel-lang/trunk/src/[language-code] resources/lang/[language-code]
+
+# Laravel 4:
+svn export https://github.com/caouecs/Laravel-lang/branches/laravel4/[language-code] app/lang/[language-code]
 ```
 
-Replace [language-code] by any of the languages listed [here](src).
+Replace `[language-code]` by any of the languages listed [here](src).
 
 ## Usage [Laravel only]
 
-In the file *app/config/app.php*, change the value of *locale* by the short name of your language.
+In the file *config/app.php*, change the value of *locale* by the short name of your language (*app/config/app.php* in Laravel 4).
 
 ## Change log
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ In this repository, you can find the lang files for the framework PHP, [Laravel 
     * `master` for Laravel5 project
  * Copy the folders of languages that you want, in *app/lang* folder of your application Laravel
 
+#### Via SVN
+
+Run this in your project directory:
+
+```
+svn export https://github.com/caouecs/Laravel-lang/trunk/src/[language-code] resources/lang/[language-code]
+```
+
+Replace [language-code] by any of the languages listed [here](src).
+
 ## Usage [Laravel only]
 
 In the file *app/config/app.php*, change the value of *locale* by the short name of your language.


### PR DESCRIPTION
- Add a shorter way to download the language files (from http://stackoverflow.com/a/18324458/5341740)
- Fixed some markdown style issues
- Updated file paths to Laravel 5 location. Some places mentioned
  Laravel 4 locations, and some both Laravel 4 & 5. I think it's better
  and less noisy to just use the most recent one. Unless there is a
  good reason not to?
