### PR TITLE
Fix Dutch 'underscore' translation

### DIFF
--- a/src/nl/validation.php
+++ b/src/nl/validation.php
@@ -18,7 +18,7 @@ return [
     'after'                => ':attribute moet een datum na :date zijn.',
     'after_or_equal'       => ':attribute moet een datum na of gelijk aan :date zijn.',
     'alpha'                => ':attribute mag alleen letters bevatten.',
-    'alpha_dash'           => ':attribute mag alleen letters, nummers, liggend streepje (_) en streepjes (-) bevatten.',
+    'alpha_dash'           => ':attribute mag alleen letters, nummers, underscores (_) en streepjes (-) bevatten.',
     'alpha_num'            => ':attribute mag alleen letters en nummers bevatten.',
     'array'                => ':attribute moet geselecteerde elementen bevatten.',
     'before'               => ':attribute moet een datum voor :date zijn.',


### PR DESCRIPTION
In Dutch, 'liggend streepje' is a dash, see https://nl.wikipedia.org/wiki/Liggend_streepje_(leesteken).
I think it is common to just use 'underscore' in Dutch (https://nl.wikipedia.org/wiki/Underscore).