### PR TITLE
[de] Removed old text for validation.alpha_dash

### DIFF
--- a/src/de/validation.php
+++ b/src/de/validation.php
@@ -18,7 +18,7 @@ return [
     'after'                => ':attribute muss ein Datum nach dem :date sein.',
     'after_or_equal'       => ':attribute muss ein Datum nach dem :date oder gleich dem :date sein.',
     'alpha'                => ':attribute darf nur aus Buchstaben bestehen.',
-    'alpha_dash'           => ':attribute darf nur aus Buchstaben, Zahlen, Binde- und Unterstrichen bestehen. Umlaute (ä, ö, ü) und Eszett (ß) sind nicht erlaubt.',
+    'alpha_dash'           => ':attribute darf nur aus Buchstaben, Zahlen, Binde- und Unterstrichen bestehen.',
     'alpha_num'            => ':attribute darf nur aus Buchstaben und Zahlen bestehen.',
     'array'                => ':attribute muss ein Array sein.',
     'before'               => ':attribute muss ein Datum vor dem :date sein.',


### PR DESCRIPTION
"Umlaute (ä, ö, ü) und Eszett (ß) sind nicht erlaubt."
They are valid in Laravel 5.4:
https://github.com/illuminate/validation/blob/5.4/Concerns/ValidatesAttributes.php#L243