### PR TITLE
şifre değil parola

### DIFF
--- a/src/tr/passwords.php
+++ b/src/tr/passwords.php
@@ -12,9 +12,9 @@ return [
     |
     */
 
-    'password' => 'Şifreler en az altı karakter olmalı ve onay ile eşleşmelidir.',
-    'reset' => 'Şifreniz sıfırlandı!',
-    'sent' => 'Şifre sıfırlama bağlantınızı size e-posta ile gönderdik!',
-    'token' => 'Şifre sıfırlama adresi/kodu geçersiz.',
+    'password' => 'Parolanız en az altı karakter olmalı ve doğrulama ile eşleşmelidir.',
+    'reset' => 'Parolanız sıfırlandı!',
+    'sent' => 'Parola sıfırlama bağlantınız e-posta ile gönderildi!',
+    'token' => 'Parola sıfırlama adresi/kodu geçersiz.',
     'user' => 'Bu e-posta adresi ile kayıtlı bir üye bulunmuyor.',
 ];


### PR DESCRIPTION
"Şifre" actually means "cipher" (as in encryption) in Turkish, "parola" is the correct translation of "password"