### PR TITLE
Corrected the translation "address" to Catalan

### DIFF
--- a/src/ca/validation.php
+++ b/src/ca/validation.php
@@ -125,7 +125,7 @@ return [
         'password_confirmation' => 'confirmació de la contrasenya',
         'city' => 'ciutat',
         'country' => 'país',
-        'address' => 'direcció',
+        'address' => 'adreça',
         'phone' => 'telèfon',
         'mobile' => 'mòbil',
         'age' => 'edat',


### PR DESCRIPTION
Reference: https://community.languagetool.org/rule/show/DIRECCIO_ADRECA?lang=ca&subId=2