### PR TITLE
[nb] Max-rule for files is wrong

### DIFF
--- a/src/nb/validation.php
+++ b/src/nb/validation.php
@@ -76,7 +76,7 @@ return [
     'max'                  => [
         'numeric' => ':attribute må ikke være større enn :max.',
         'file'    => ':attribute må ikke være større enn :max kilobytes.',
-        'string'  => ':attribute må ikke være kortere enn :max tegn.',
+        'string'  => ':attribute må ikke være lengre enn :max tegn.',
         'array'   => ':attribute må ikke ha flere enn :max elementer.',
     ],
     'mimes'                => ':attribute må være en fil av typen: :values.',


### PR DESCRIPTION
If I translate the current Norwegian max-rule for strings back to English, it reads:
```:attribute must not be shorter than :max characters```
... which is the exact opposite of what this validation error text is meant to convey. After the change, it will translate to:
```:attribute must not be greater than :max characters```