### PR TITLE
[de-CH] Add Swiss standard German 

### DIFF
--- a/src/de-CH/auth.php
+++ b/src/de-CH/auth.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed'   => 'Diese Kombination aus Zugangsdaten wurde nicht in unserer Datenbank gefunden.',
+    'throttle' => 'Zu viele Loginversuche. Versuchen Sie es bitte in :seconds Sekunden nochmal.',
+];

--- a/src/de-CH/pagination.php
+++ b/src/de-CH/pagination.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; Zurück',
+    'next'     => 'Weiter &raquo;',
+];

--- a/src/de-CH/passwords.php
+++ b/src/de-CH/passwords.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reminder Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'password' => 'Passwörter müssen mindestens 6 Zeichen lang sein und korrekt bestätigt werden.',
+    'reset'    => 'Das Passwort wurde zurückgesetzt!',
+    'sent'     => 'Passworterinnerung wurde gesendet!',
+    'token'    => 'Der Passwort-Wiederherstellungs-Schlüssel ist ungültig oder abgelaufen.',
+    'user'     => 'Es konnte leider kein Nutzer mit dieser E-Mail-Adresse gefunden werden.',
+];

--- a/src/de-CH/validation.php
+++ b/src/de-CH/validation.php
@@ -1,0 +1,174 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | as the size rules. Feel free to tweak each of these messages.
+    |
+    */
+
+    'accepted'             => ':attribute muss akzeptiert werden.',
+    'active_url'           => ':attribute ist keine gültige Internet-Adresse.',
+    'after'                => ':attribute muss ein Datum nach dem :date sein.',
+    'after_or_equal'       => ':attribute muss ein Datum nach dem :date oder gleich dem :date sein.',
+    'alpha'                => ':attribute darf nur aus Buchstaben bestehen.',
+    'alpha_dash'           => ':attribute darf nur aus Buchstaben, Zahlen, Binde- und Unterstrichen bestehen.',
+    'alpha_num'            => ':attribute darf nur aus Buchstaben und Zahlen bestehen.',
+    'array'                => ':attribute muss ein Array sein.',
+    'before'               => ':attribute muss ein Datum vor dem :date sein.',
+    'before_or_equal'      => ':attribute muss ein Datum vor dem :date oder gleich dem :date sein.',
+    'between'              => [
+        'numeric' => ':attribute muss zwischen :min & :max liegen.',
+        'file'    => ':attribute muss zwischen :min & :max Kilobytes gross sein.',
+        'string'  => ':attribute muss zwischen :min & :max Zeichen lang sein.',
+        'array'   => ':attribute muss zwischen :min & :max Elemente haben.',
+    ],
+    'boolean'              => ":attribute muss entweder 'true' oder 'false' sein.",
+    'confirmed'            => ':attribute stimmt nicht mit der Bestätigung überein.',
+    'date'                 => ':attribute muss ein gültiges Datum sein.',
+    'date_format'          => ':attribute entspricht nicht dem gültigen Format für :format.',
+    'different'            => ':attribute und :other müssen sich unterscheiden.',
+    'digits'               => ':attribute muss :digits Stellen haben.',
+    'digits_between'       => ':attribute muss zwischen :min und :max Stellen haben.',
+    'dimensions'           => ':attribute hat ungültige Bildabmessungen.',
+    'distinct'             => ':attribute beinhaltet einen bereits vorhandenen Wert.',
+    'email'                => ':attribute muss eine gültige E-Mail-Adresse sein.',
+    'exists'               => 'Der gewählte Wert für :attribute ist ungültig.',
+    'file'                 => ':attribute muss eine Datei sein.',
+    'filled'               => ':attribute muss ausgefüllt sein.',
+    'gt'                   => [
+        'numeric' => ':attribute muss mindestens :min sein.',
+        'file'    => ':attribute muss mindestens :min Kilobytes gross sein.',
+        'string'  => ':attribute muss mindestens :min Zeichen lang sein.',
+        'array'   => ':attribute muss mindestens :min Elemente haben.',
+    ],
+    'gte'                  => [
+        'numeric' => ':attribute muss grösser oder gleich :min sein.',
+        'file'    => ':attribute muss grösser oder gleich :min Kilobytes sein.',
+        'string'  => ':attribute muss grösser oder gleich :min Zeichen lang sein.',
+        'array'   => ':attribute muss grösser oder gleich :min Elemente haben.',
+    ],
+    'image'                => ':attribute muss ein Bild sein.',
+    'in'                   => 'Der gewählte Wert für :attribute ist ungültig.',
+    'in_array'             => 'Der gewählte Wert für :attribute kommt nicht in :other vor.',
+    'integer'              => ':attribute muss eine ganze Zahl sein.',
+    'ip'                   => ':attribute muss eine gültige IP-Adresse sein.',
+    'ipv4'                 => ':attribute muss eine gültige IPv4-Adresse sein.',
+    'ipv6'                 => ':attribute muss eine gültige IPv6-Adresse sein.',
+    'json'                 => ':attribute muss ein gültiger JSON-String sein.',
+    'lt'                   => [
+        'numeric' => ':attribute muss kleiner :min sein.',
+        'file'    => ':attribute muss kleiner :min Kilobytes gross sein.',
+        'string'  => ':attribute muss kleiner :min Zeichen lang sein.',
+        'array'   => ':attribute muss kleiner :min Elemente haben.',
+    ],
+    'lte'                  => [
+        'numeric' => ':attribute muss kleiner oder gleich :min sein.',
+        'file'    => ':attribute muss kleiner oder gleich :min Kilobytes sein.',
+        'string'  => ':attribute muss kleiner oder gleich :min Zeichen lang sein.',
+        'array'   => ':attribute muss kleiner oder gleich :min Elemente haben.',
+    ],
+    'max'                  => [
+        'numeric' => ':attribute darf maximal :max sein.',
+        'file'    => ':attribute darf maximal :max Kilobytes gross sein.',
+        'string'  => ':attribute darf maximal :max Zeichen haben.',
+        'array'   => ':attribute darf nicht mehr als :max Elemente haben.',
+    ],
+    'mimes'                => ':attribute muss den Dateityp :values haben.',
+    'mimetypes'            => ':attribute muss den Dateityp :values haben.',
+    'min'                  => [
+        'numeric' => ':attribute muss mindestens :min sein.',
+        'file'    => ':attribute muss mindestens :min Kilobytes gross sein.',
+        'string'  => ':attribute muss mindestens :min Zeichen lang sein.',
+        'array'   => ':attribute muss mindestens :min Elemente haben.',
+    ],
+    'not_in'               => 'Der gewählte Wert für :attribute ist ungültig.',
+    'not_regex'            => ':attribute hat ein ungültiges Format.',
+    'numeric'              => ':attribute muss eine Zahl sein.',
+    'present'              => ':attribute muss vorhanden sein.',
+    'regex'                => ':attribute Format ist ungültig.',
+    'required'             => ':attribute muss ausgefüllt sein.',
+    'required_if'          => ':attribute muss ausgefüllt sein, wenn :other :value ist.',
+    'required_unless'      => ':attribute muss ausgefüllt sein, wenn :other nicht :values ist.',
+    'required_with'        => ':attribute muss angegeben werden, wenn :values ausgefüllt wurde.',
+    'required_with_all'    => ':attribute muss angegeben werden, wenn :values ausgefüllt wurde.',
+    'required_without'     => ':attribute muss angegeben werden, wenn :values nicht ausgefüllt wurde.',
+    'required_without_all' => ':attribute muss angegeben werden, wenn keines der Felder :values ausgefüllt wurde.',
+    'same'                 => ':attribute und :other müssen übereinstimmen.',
+    'size'                 => [
+        'numeric' => ':attribute muss gleich :size sein.',
+        'file'    => ':attribute muss :size Kilobyte gross sein.',
+        'string'  => ':attribute muss :size Zeichen lang sein.',
+        'array'   => ':attribute muss genau :size Elemente haben.',
+    ],
+    'string'               => ':attribute muss ein String sein.',
+    'timezone'             => ':attribute muss eine gültige Zeitzone sein.',
+    'unique'               => ':attribute ist schon vergeben.',
+    'uploaded'             => ':attribute konnte nicht hochgeladen werden.',
+    'url'                  => ':attribute muss eine URL sein.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap attribute place-holders
+    | with something more reader friendly such as E-Mail Address instead
+    | of "email". This simply helps us make messages a little cleaner.
+    |
+    */
+
+    'attributes' => [
+        'name'                  => 'Name',
+        'username'              => 'Benutzername',
+        'email'                 => 'E-Mail-Adresse',
+        'first_name'            => 'Vorname',
+        'last_name'             => 'Nachname',
+        'password'              => 'Passwort',
+        'password_confirmation' => 'Passwort-Bestätigung',
+        'city'                  => 'Stadt',
+        'country'               => 'Land',
+        'address'               => 'Adresse',
+        'phone'                 => 'Telefonnummer',
+        'mobile'                => 'Handynummer',
+        'age'                   => 'Alter',
+        'sex'                   => 'Geschlecht',
+        'gender'                => 'Geschlecht',
+        'day'                   => 'Tag',
+        'month'                 => 'Monat',
+        'year'                  => 'Jahr',
+        'hour'                  => 'Stunde',
+        'minute'                => 'Minute',
+        'second'                => 'Sekunde',
+        'title'                 => 'Titel',
+        'content'               => 'Inhalt',
+        'description'           => 'Beschreibung',
+        'excerpt'               => 'Auszug',
+        'date'                  => 'Datum',
+        'time'                  => 'Uhrzeit',
+        'available'             => 'verfügbar',
+        'size'                  => 'Grösse',
+    ],
+];


### PR DESCRIPTION
The Swiss do not use "ß". This PR creates a new language and replaces ß with 'ss'.

For reference: https://en.wikipedia.org/wiki/%C3%9F#Switzerland_and_Liechtenstein

**Attention**: Although it would be funny, this is NOT swiss-german. This is just the localized version of German for Switzerland, thus de-CH.