### PR TITLE
[NL] Use more common word "tekst" for string

### DIFF
--- a/src/nl/validation.php
+++ b/src/nl/validation.php
@@ -106,7 +106,7 @@ return [
         'string'  => ':attribute moet :size karakters zijn.',
         'array'   => ':attribute moet :size items bevatten.',
     ],
-    'string'               => ':attribute moet een tekenreeks zijn.',
+    'string'               => ':attribute moet een tekst zijn.',
     'timezone'             => ':attribute moet een geldige tijdzone zijn.',
     'unique'               => ':attribute is al in gebruik.',
     'uploaded'             => 'Het uploaden van :attribute is mislukt.',


### PR DESCRIPTION
'tekenreeks' is very uncommonly used and will likely confuse users. 'tekst' on the other hand is a more common phrase to refer to text. 

Signed-off-by: MegaXLR <admin@megaxlr.net>