### PR TITLE
Fixed link to badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Laravel-lang
 
-[![Stories in Ready](https://badge.waffle.io/caouecs/Laravel-lang.svg?label=ready&title=Ready)](http://waffle.io/caouecs/Laravel-lang)
+[![Stories in Ready](https://badge.waffle.io/caouecs/Laravel-lang.svg)](http://waffle.io/caouecs/Laravel-lang)
 
 In this repository, you can find the lang files for the framework PHP, [Laravel 4&5](http://www.laravel.com).
 


### PR DESCRIPTION
The current image looks like this:
![2018-08-16 21-02-29 caouecs laravel-lang list of 68 languages for laravel 5 - google chrome](https://user-images.githubusercontent.com/10347617/44226305-6cf69380-a198-11e8-92a5-504ee53b1e76.png)

Corrected like this:
[![Stories in Ready](https://badge.waffle.io/caouecs/Laravel-lang.svg)](http://waffle.io/caouecs/Laravel-lang)