### PR TITLE
[de] Added translation for UUID

### DIFF
--- a/src/de/validation.php
+++ b/src/de/validation.php
@@ -111,7 +111,7 @@ return [
     'unique'               => ':attribute ist schon vergeben.',
     'uploaded'             => ':attribute konnte nicht hochgeladen werden.',
     'url'                  => ':attribute muss eine URL sein.',
-    'uuid'                 => 'The :attribute must be a valid UUID.',
+    'uuid'                 => ':attribute muss ein UUID sein.',
 
     /*
     |--------------------------------------------------------------------------

--- a/todo.md
+++ b/todo.md
@@ -570,7 +570,6 @@ into your web browser: [:actionURL](:actionURL) : not present
 #### de:
 
   * json : Name
-  * validation : uuid
 
 [ [to top](#todo-list) ]
 


### PR DESCRIPTION
The todo list says that a translation is needed for the field `Name` in json.
In German, `Name` is written in the same way as in English, so this entry will be in the todo list.