### PR TITLE
update comment to match Taylor's style

### DIFF
--- a/src/ar/validation.php
+++ b/src/ar/validation.php
@@ -8,7 +8,7 @@ return [
     |
     | The following language lines contain the default error messages used by
     | the validator class. Some of these rules have multiple versions such
-    | as the size rules. Feel free to tweak each of these messages.
+    | as the size rules. Feel free to tweak each of these messages here.
     |
     */
 


### PR DESCRIPTION
Taylor makes every line of a block comment 3 characters less than the previous line. This change is a copy-paste from his comments in the English version.