### PR TITLE
fix grammar error in predicate of kaan - AR

### DIFF
--- a/src/ar/validation.php
+++ b/src/ar/validation.php
@@ -8,7 +8,7 @@ return [
     |
     | The following language lines contain the default error messages used by
     | the validator class. Some of these rules have multiple versions such
-    | as the size rules. Feel free to tweak each of these messages.
+    | as the size rules. Feel free to tweak each of these messages here.
     |
     */
 
@@ -33,7 +33,7 @@ return [
     'date'                 => ':attribute ليس تاريخًا صحيحًا.',
     'date_equals'          => 'يجب أن يكون :attribute مطابقاً للتاريخ :date.',
     'date_format'          => 'لا يتوافق :attribute مع الشكل :format.',
-    'different'            => 'يجب أن يكون الحقلان :attribute و :other مُختلفان.',
+    'different'            => 'يجب أن يكون الحقلان :attribute و :other مُختلفين.',
     'digits'               => 'يجب أن يحتوي :attribute على :digits رقمًا/أرقام.',
     'digits_between'       => 'يجب أن يحتوي :attribute بين :min و :max رقمًا/أرقام .',
     'dimensions'           => 'الـ :attribute يحتوي على أبعاد صورة غير صالحة.',


### PR DESCRIPTION
A grammatical rule requires the predicate (khabar) of "kaan" to be in the accusative case (mansoob). Thus, the ending "yaa + noon" for the dual is expected rather than the current "alif + noon."