### PR TITLE
Fix: markdown link should not have any space

### DIFF
--- a/json/es.json
+++ b/json/es.json
@@ -14,7 +14,7 @@
   "If you did not create an account, no further action is required.": "Si no ha creado una cuenta, no se requiere ninguna acción adicional.",
   "If you did not receive the email": "Si no ha recibido el correo electrónico",
   "If you did not request a password reset, no further action is required.": "Si no ha solicitado el restablecimiento de contraseña, omita este correo electrónico.",
-  "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser: [:actionURL](:actionURL)": "Si tiene problemas para hacer clic en el botón \":actionText\", copie y pegue la URL a continuación \nen su navegador web: [:actionURL] (:actionURL)",
+  "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser: [:actionURL](:actionURL)": "Si tiene problemas para hacer clic en el botón \":actionText\", copie y pegue la URL a continuación \nen su navegador web: [:actionURL](:actionURL)",
   "Login": "Entrar",
   "Logout": "Salir",
   "Name": "Nombre",


### PR DESCRIPTION
Hi,
there should not be any space between
```
[:actionURL] (:actionURL)
```

Markdown parser is not considering it a link when there is a space.

