### PR TITLE
[pl] Update the password string

### DIFF
--- a/src/pl/passwords.php
+++ b/src/pl/passwords.php
@@ -12,7 +12,7 @@ return [
     |
     */
 
-    'password' => 'Hasło musi mieć przynajmniej sześć znaków i zgadzać się z potwierdzeniem.',
+    'password' => 'Hasło musi mieć przynajmniej osiem znaków i zgadzać się z potwierdzeniem.',
     'reset'    => 'Hasło zostało zresetowane!',
     'sent'     => 'Przypomnienie hasła zostało wysłane!',
     'token'    => 'Token resetowania hasła jest nieprawidłowy.',


### PR DESCRIPTION
The default required length for the password is eight digits as of Laravel 5.8.0.