### PR TITLE
[VI] Update the password string

### DIFF
--- a/src/vi/passwords.php
+++ b/src/vi/passwords.php
@@ -12,7 +12,7 @@ return [
     |
     */
 
-    'password' => 'Mật khẩu phải gồm 6 ký tự và khớp với phần xác nhận.',
+    'password' => 'Mật khẩu phải gồm 8 ký tự và khớp với phần xác nhận.',
     'reset'    => 'Mật khẩu mới đã được cập nhật!',
     'sent'     => 'Hướng dẫn cấp lại mật khẩu đã được gửi!',
     'token'    => 'Mã khôi phục mật khẩu không hợp lệ.',


### PR DESCRIPTION
The default required length for the password is eight digits as of Laravel 5.8.0.