### PR TITLE
Modify Lithuanian pagination translation

### DIFF
--- a/src/lt/pagination.php
+++ b/src/lt/pagination.php
@@ -13,5 +13,5 @@ return [
     */
 
     'previous' => '&laquo; Ankstesnis',
-    'next'     => 'Sekantis &raquo;',
+    'next'     => 'Kitas &raquo;',
 ];


### PR DESCRIPTION
According to Lithuanian language rules word "sekantis" can not be used in pagination context.

References:
- http://www.vlkk.lt/konsultacijos/2710-sekantis
- http://zemynosgimnazija.lt/kalbekime_taisyklingai/sekantis_kitas.pdf