### PR TITLE
[id] Add validation for ends_with & general grammatical changes in validation

### DIFF
--- a/src/id/validation.php
+++ b/src/id/validation.php
@@ -1,5 +1,4 @@
 <?php
-
 return [
     /*
     |---------------------------------------------------------------------------------------
@@ -7,143 +6,138 @@ return [
     |---------------------------------------------------------------------------------------
     |
     | Baris bahasa berikut ini berisi standar pesan kesalahan yang digunakan oleh
-    | kelas validasi. Beberapa aturan mempunyai multi versi seperti aturan 'size'.
+    | kelas validasi. Beberapa aturan mempunyai banyak versi seperti aturan 'size'.
     | Jangan ragu untuk mengoptimalkan setiap pesan yang ada di sini.
     |
     */
-
-    'accepted'             => 'Isian :attribute harus diterima.',
-    'active_url'           => 'Isian :attribute bukan URL yang valid.',
-    'after'                => 'Isian :attribute harus tanggal setelah :date.',
-    'after_or_equal'       => 'Isian :attribute harus berupa tanggal setelah atau sama dengan tanggal :date.',
-    'alpha'                => 'Isian :attribute hanya boleh berisi huruf.',
-    'alpha_dash'           => 'Isian :attribute hanya boleh berisi huruf, angka, dan strip.',
-    'alpha_num'            => 'Isian :attribute hanya boleh berisi huruf dan angka.',
-    'array'                => 'Isian :attribute harus berupa sebuah array.',
-    'before'               => 'Isian :attribute harus tanggal sebelum :date.',
-    'before_or_equal'      => 'Isian :attribute harus berupa tanggal sebelum atau sama dengan tanggal :date.',
+    'accepted'             => ':attribute harus diterima.',
+    'active_url'           => ':attribute bukan URL yang valid.',
+    'after'                => ':attribute harus berisi tanggal setelah :date.',
+    'after_or_equal'       => ':attribute harus berisi tanggal setelah atau sama dengan :date.',
+    'alpha'                => ':attribute hanya boleh berisi huruf.',
+    'alpha_dash'           => ':attribute hanya boleh berisi huruf, angka, strip, dan garis bawah.',
+    'alpha_num'            => ':attribute hanya boleh berisi huruf dan angka.',
+    'array'                => ':attribute harus berisi sebuah array.',
+    'before'               => ':attribute harus berisi tanggal sebelum :date.',
+    'before_or_equal'      => ':attribute harus berisi tanggal sebelum atau sama dengan :date.',
     'between'              => [
-        'numeric' => 'Isian :attribute harus antara :min dan :max.',
-        'file'    => 'Bidang :attribute harus antara :min dan :max kilobita.',
-        'string'  => 'Isian :attribute harus antara :min dan :max karakter.',
-        'array'   => 'Isian :attribute harus antara :min dan :max item.',
+        'numeric' => ':attribute harus bernilai antara :min sampai :max.',
+        'file'    => ':attribute harus berukuran antara :min sampai :max kilobita.',
+        'string'  => ':attribute harus berisi antara :min sampai :max karakter.',
+        'array'   => ':attribute harus memiliki :min sampai :max anggota.',
     ],
-    'boolean'              => 'Isian :attribute harus berupa true atau false',
+    'boolean'              => ':attribute harus bernilai true atau false',
     'confirmed'            => 'Konfirmasi :attribute tidak cocok.',
-    'date'                 => 'Isian :attribute bukan tanggal yang valid.',
-    'date_equals'          => ':attribute harus berupa tanggal yang sama dengan :date.',
-    'date_format'          => 'Isian :attribute tidak cocok dengan format :format.',
-    'different'            => 'Isian :attribute dan :other harus berbeda.',
-    'digits'               => 'Isian :attribute harus berupa angka :digits.',
-    'digits_between'       => 'Isian :attribute harus antara angka :min dan :max.',
-    'dimensions'           => 'Bidang :attribute tidak memiliki dimensi gambar yang valid.',
-    'distinct'             => 'Bidang isian :attribute memiliki nilai yang duplikat.',
-    'email'                => 'Isian :attribute harus berupa alamat surel yang valid.',
-    'ends_with'            => 'The :attribute must end with one of the following: :values',
-    'exists'               => 'Isian :attribute yang dipilih tidak valid.',
-    'file'                 => 'Bidang :attribute harus berupa sebuah berkas.',
-    'filled'               => 'Isian :attribute harus memiliki nilai.',
+    'date'                 => ':attribute bukan tanggal yang valid.',
+    'date_equals'          => ':attribute harus berisi tanggal yang sama dengan :date.',
+    'date_format'          => ':attribute tidak cocok dengan format :format.',
+    'different'            => ':attribute dan :other harus berbeda.',
+    'digits'               => ':attribute harus terdiri dari :digits angka.',
+    'digits_between'       => ':attribute harus terdiri dari :min sampai :max angka.',
+    'dimensions'           => ':attribute tidak memiliki dimensi gambar yang valid.',
+    'distinct'             => ':attribute memiliki nilai yang duplikat.',
+    'email'                => ':attribute harus berupa alamat surel yang valid.',
+    'ends_with'            => ':attribute harus diakhiri salah satu dari berikut: :values',
+    'exists'               => ':attribute yang dipilih tidak valid.',
+    'file'                 => ':attribute harus berupa sebuah berkas.',
+    'filled'               => ':attribute harus memiliki nilai.',
     'gt'                   => [
-        'numeric' => 'Isian :attribute harus lebih besar dari :value.',
-        'file'    => 'Bidang :attribute harus lebih besar dari :value kilobita.',
-        'string'  => 'Isian :attribute harus lebih besar dari :value karakter.',
-        'array'   => 'Isian :attribute harus lebih dari :value item.',
+        'numeric' => ':attribute harus bernilai lebih besar dari :value.',
+        'file'    => ':attribute harus berukuran lebih besar dari :value kilobita.',
+        'string'  => ':attribute harus berisi lebih besar dari :value karakter.',
+        'array'   => ':attribute harus memiliki lebih dari :value anggota.',
     ],
     'gte'                  => [
-        'numeric' => 'Isian :attribute harus lebih besar dari atau sama dengan :value.',
-        'file'    => 'Bidang :attribute harus lebih besar dari atau sama dengan :value kilobita.',
-        'string'  => 'Isian :attribute harus lebih besar dari atau sama dengan :value karakter.',
-        'array'   => 'Isian :attribute harus mempunyai :value item atau lebih.',
+        'numeric' => ':attribute harus bernilai lebih besar dari atau sama dengan :value.',
+        'file'    => ':attribute harus berukuran lebih besar dari atau sama dengan :value kilobita.',
+        'string'  => ':attribute harus berisi lebih besar dari atau sama dengan :value karakter.',
+        'array'   => ':attribute harus terdiri dari :value anggota atau lebih.',
     ],
-    'image'                => 'Isian :attribute harus berupa gambar.',
-    'in'                   => 'Isian :attribute yang dipilih tidak valid.',
-    'in_array'             => 'Bidang isian :attribute tidak terdapat dalam :other.',
-    'integer'              => 'Isian :attribute harus merupakan bilangan bulat.',
-    'ip'                   => 'Isian :attribute harus berupa alamat IP yang valid.',
-    'ipv4'                 => 'Isian :attribute harus berupa alamat IPv4 yang valid.',
-    'ipv6'                 => 'Isian :attribute harus berupa alamat IPv6 yang valid.',
-    'json'                 => 'Isian :attribute harus berupa JSON string yang valid.',
+    'image'                => ':attribute harus berupa gambar.',
+    'in'                   => ':attribute yang dipilih tidak valid.',
+    'in_array'             => ':attribute tidak ada di dalam :other.',
+    'integer'              => ':attribute harus berupa bilangan bulat.',
+    'ip'                   => ':attribute harus berupa alamat IP yang valid.',
+    'ipv4'                 => ':attribute harus berupa alamat IPv4 yang valid.',
+    'ipv6'                 => ':attribute harus berupa alamat IPv6 yang valid.',
+    'json'                 => ':attribute harus berupa JSON string yang valid.',
     'lt'                   => [
-        'numeric' => 'Isian :attribute harus kurang dari :value.',
-        'file'    => 'Bidang :attribute harus kurang dari :value kilobita.',
-        'string'  => 'Isian :attribute harus kurang dari :value karakter.',
-        'array'   => 'Isian :attribute harus kurang dari :value item.',
+        'numeric' => ':attribute harus bernilai kurang dari :value.',
+        'file'    => ':attribute harus berukuran kurang dari :value kilobita.',
+        'string'  => ':attribute harus berisi kurang dari :value karakter.',
+        'array'   => ':attribute harus memiliki kurang dari :value anggota.',
     ],
     'lte'                  => [
-        'numeric' => 'Isian :attribute harus kurang dari atau sama dengan :value.',
-        'file'    => 'Bidang :attribute harus kurang dari atau sama dengan :value kilobita.',
-        'string'  => 'Isian :attribute harus kurang dari atau sama dengan :value karakter.',
-        'array'   => 'Isian :attribute harus tidak lebih dari :value item.',
+        'numeric' => ':attribute harus bernilai kurang dari atau sama dengan :value.',
+        'file'    => ':attribute harus berukuran kurang dari atau sama dengan :value kilobita.',
+        'string'  => ':attribute harus berisi kurang dari atau sama dengan :value karakter.',
+        'array'   => ':attribute harus tidak lebih dari :value anggota.',
     ],
     'max'                  => [
-        'numeric' => 'Isian :attribute seharusnya tidak lebih dari :max.',
-        'file'    => 'Bidang :attribute seharusnya tidak lebih dari :max kilobita.',
-        'string'  => 'Isian :attribute seharusnya tidak lebih dari :max karakter.',
-        'array'   => 'Isian :attribute seharusnya tidak lebih dari :max item.',
+        'numeric' => ':attribute maskimal bernilai :max.',
+        'file'    => ':attribute maksimal berukuran :max kilobita.',
+        'string'  => ':attribute maskimal berisi :max karakter.',
+        'array'   => ':attribute maksimal terdiri dari :max anggota.',
     ],
-    'mimes'                => 'Isian :attribute harus dokumen berjenis : :values.',
-    'mimetypes'            => 'Isian :attribute harus dokumen berjenis : :values.',
+    'mimes'                => ':attribute harus berupa berkas berjenis: :values.',
+    'mimetypes'            => ':attribute harus berupa berkas berjenis: :values.',
     'min'                  => [
-        'numeric' => 'Isian :attribute harus minimal :min.',
-        'file'    => 'Bidang :attribute harus minimal :min kilobita.',
-        'string'  => 'Isian :attribute harus minimal :min karakter.',
-        'array'   => 'Isian :attribute harus minimal :min item.',
+        'numeric' => ':attribute minimal bernilai :min.',
+        'file'    => ':attribute minimal berukuran :min kilobita.',
+        'string'  => ':attribute minimal berisi :min karakter.',
+        'array'   => ':attribute minimal terdiri dari :min anggota.',
     ],
-    'not_in'               => 'Isian :attribute yang dipilih tidak valid.',
-    'not_regex'            => 'Format isian :attribute tidak valid.',
-    'numeric'              => 'Isian :attribute harus berupa angka.',
-    'present'              => 'Bidang isian :attribute wajib ada.',
-    'regex'                => 'Format isian :attribute tidak valid.',
-    'required'             => 'Bidang isian :attribute wajib diisi.',
-    'required_if'          => 'Bidang isian :attribute wajib diisi bila :other adalah :value.',
-    'required_unless'      => 'Bidang isian :attribute wajib diisi kecuali :other memiliki nilai :values.',
-    'required_with'        => 'Bidang isian :attribute wajib diisi bila terdapat :values.',
-    'required_with_all'    => 'Bidang isian :attribute wajib diisi bila terdapat :values.',
-    'required_without'     => 'Bidang isian :attribute wajib diisi bila tidak terdapat :values.',
-    'required_without_all' => 'Bidang isian :attribute wajib diisi bila tidak terdapat ada :values.',
-    'same'                 => 'Isian :attribute dan :other harus sama.',
+    'not_in'               => ':attribute yang dipilih tidak valid.',
+    'not_regex'            => 'Format :attribute tidak valid.',
+    'numeric'              => ':attribute harus berupa angka.',
+    'present'              => ':attribute wajib ada.',
+    'regex'                => 'Format :attribute tidak valid.',
+    'required'             => ':attribute wajib diisi.',
+    'required_if'          => ':attribute wajib diisi bila :other adalah :value.',
+    'required_unless'      => ':attribute wajib diisi kecuali :other memiliki nilai :values.',
+    'required_with'        => ':attribute wajib diisi bila terdapat :values.',
+    'required_with_all'    => ':attribute wajib diisi bila terdapat :values.',
+    'required_without'     => ':attribute wajib diisi bila tidak terdapat :values.',
+    'required_without_all' => ':attribute wajib diisi bila sama sekali tidak terdapat :values.',
+    'same'                 => ':attribute dan :other harus sama.',
     'size'                 => [
-        'numeric' => 'Isian :attribute harus berukuran :size.',
-        'file'    => 'Bidang :attribute harus berukuran :size kilobyte.',
-        'string'  => 'Isian :attribute harus berukuran :size karakter.',
-        'array'   => 'Isian :attribute harus mengandung :size item.',
+        'numeric' => ':attribute harus berukuran :size.',
+        'file'    => ':attribute harus berukuran :size kilobyte.',
+        'string'  => ':attribute harus berukuran :size karakter.',
+        'array'   => ':attribute harus mengandung :size anggota.',
     ],
     'starts_with'          => ':attribute harus diawali salah satu dari berikut: :values',
-    'string'               => 'Isian :attribute harus berupa string.',
-    'timezone'             => 'Isian :attribute harus berupa zona waktu yang valid.',
-    'unique'               => 'Isian :attribute sudah ada sebelumnya.',
-    'uploaded'             => 'Isian :attribute gagal diunggah.',
-    'url'                  => 'Format isian :attribute tidak valid.',
+    'string'               => ':attribute harus berupa string.',
+    'timezone'             => ':attribute harus berisi zona waktu yang valid.',
+    'unique'               => ':attribute sudah ada sebelumnya.',
+    'uploaded'             => ':attribute gagal diunggah.',
+    'url'                  => 'Format :attribute tidak valid.',
     'uuid'                 => ':attribute harus merupakan UUID yang valid.',
-
     /*
     |---------------------------------------------------------------------------------------
     | Baris Bahasa untuk Validasi Kustom
     |---------------------------------------------------------------------------------------
     |
-    | Di sini Anda dapat menentukan pesan validasi kustom untuk atribut dengan menggunakan
-    | konvensi "attribute.rule" dalam penamaan baris. Hal ini membuat cepat dalam
-    | menentukan spesifik baris bahasa kustom untuk aturan atribut yang diberikan.
+    | Di sini Anda dapat menentukan pesan validasi untuk atribut sesuai keinginan dengan 
+    | menggunakan konvensi "attribute.rule" dalam penamaan barisnya. Hal ini mempercepat 
+    | dalam menentukan baris bahasa kustom yang spesifik untuk aturan atribut yang diberikan.
     |
     */
-
     'custom' => [
         'attribute-name' => [
             'rule-name' => 'custom-message',
         ],
     ],
-
     /*
     |---------------------------------------------------------------------------------------
     | Kustom Validasi Atribut
     |---------------------------------------------------------------------------------------
     |
-    | Baris bahasa berikut digunakan untuk menukar atribut 'place-holders'
-    | dengan sesuatu yang lebih bersahabat dengan pembaca seperti Alamat Surel daripada
-    | "surel" saja. Ini benar-benar membantu kita membuat pesan sedikit bersih.
+    | Baris bahasa berikut digunakan untuk menukar 'placeholder' atribut dengan sesuatu
+    | yang lebih mudah dimengerti oleh pembaca seperti "Alamat Surel" daripada "surel" saja.
+    | Hal ini membantu kita dalam membuat pesan menjadi lebih ekspresif.
     |
     */
-
     'attributes' => [
     ],
 ];

--- a/src/id/validation.php
+++ b/src/id/validation.php
@@ -1,4 +1,5 @@
 <?php
+
 return [
     /*
     |---------------------------------------------------------------------------------------
@@ -10,6 +11,7 @@ return [
     | Jangan ragu untuk mengoptimalkan setiap pesan yang ada di sini.
     |
     */
+
     'accepted'             => ':attribute harus diterima.',
     'active_url'           => ':attribute bukan URL yang valid.',
     'after'                => ':attribute harus berisi tanggal setelah :date.',
@@ -113,6 +115,7 @@ return [
     'uploaded'             => ':attribute gagal diunggah.',
     'url'                  => 'Format :attribute tidak valid.',
     'uuid'                 => ':attribute harus merupakan UUID yang valid.',
+
     /*
     |---------------------------------------------------------------------------------------
     | Baris Bahasa untuk Validasi Kustom
@@ -123,11 +126,13 @@ return [
     | dalam menentukan baris bahasa kustom yang spesifik untuk aturan atribut yang diberikan.
     |
     */
+
     'custom' => [
         'attribute-name' => [
             'rule-name' => 'custom-message',
         ],
     ],
+
     /*
     |---------------------------------------------------------------------------------------
     | Kustom Validasi Atribut
@@ -138,6 +143,7 @@ return [
     | Hal ini membantu kita dalam membuat pesan menjadi lebih ekspresif.
     |
     */
+
     'attributes' => [
     ],
 ];


### PR DESCRIPTION
Hi,

This PR add translation for `ends_with` and changes some translations to make it more native.
- [x] Add translation for `ends_with` validation
- [x] Add missing word translation for 'underscores' in `alpha_dash` validation
- [x] Change translation for `max` validation to make it consistent with `min` validation
- [x] Change general translations to all validation
- [x] Change translation of comment documentation