### PR TITLE
[ar] Update validation.not_in

### DIFF
--- a/src/ar/validation.php
+++ b/src/ar/validation.php
@@ -89,7 +89,7 @@ return [
         'string'  => 'يجب أن يكون طول النص :attribute على الأقل :min حروفٍ/حرفًا.',
         'array'   => 'يجب أن يحتوي :attribute على الأقل على :min عُنصرًا/عناصر.',
     ],
-    'not_in'               => ':attribute موجود.',
+    'not_in'               => 'العنصر :attribute غير صحيح.',
     'not_regex'            => 'صيغة :attribute غير صحيحة.',
     'numeric'              => 'يجب على :attribute أن يكون رقمًا.',
     'present'              => 'يجب تقديم :attribute.',


### PR DESCRIPTION
The old translation was not clear this what is says
`:attribute exists`
I changed to the equivalent of the original laravel translation which says
`The selected :attribute is invalid.`