### PR TITLE
[es] The password field is not used anymore on Laravel 6

### DIFF
--- a/src/es/passwords.php
+++ b/src/es/passwords.php
@@ -12,7 +12,6 @@ return [
     |
     */
 
-    'password' => 'Las contraseñas deben coincidir y contener al menos 8 caracteres',
     'reset'    => '¡Tu contraseña ha sido restablecida!',
     'sent'     => '¡Te hemos enviado por correo el enlace para restablecer tu contraseña!',
     'token'    => 'El token de recuperación de contraseña es inválido.',


### PR DESCRIPTION
The password field in the passwords file is not used anymore on Laravel 6. Instead, it uses the password field in the validation file.