### PR TITLE
SV: Make date validation messages also work with fields

### DIFF
--- a/src/sv/validation.php
+++ b/src/sv/validation.php
@@ -14,13 +14,13 @@ return [
 
     'accepted'        => ':attribute måste accepteras.',
     'active_url'      => ':attribute är inte en giltig webbadress.',
-    'after'           => ':attribute måste vara ett datum efter den :date.',
+    'after'           => ':attribute måste vara ett datum efter :date.',
     'after_or_equal'  => ':attribute måste vara ett datum senare eller samma dag som :date.',
     'alpha'           => ':attribute får endast innehålla bokstäver.',
     'alpha_dash'      => ':attribute får endast innehålla bokstäver, siffror och bindestreck.',
     'alpha_num'       => ':attribute får endast innehålla bokstäver och siffror.',
     'array'           => ':attribute måste vara en array.',
-    'before'          => ':attribute måste vara ett datum innan den :date.',
+    'before'          => ':attribute måste vara ett datum innan :date.',
     'before_or_equal' => ':attribute måste vara ett datum före eller samma dag som :date.',
     'between'         => [
         'numeric' => ':attribute måste vara en siffra mellan :min och :max.',


### PR DESCRIPTION
This makes the after and before validation messages work equally well with dates and fields, just as the english variant.