### PR TITLE
Fix translation in es.json, translation wasn´t work in mail subcopy

### DIFF
--- a/json/es.json
+++ b/json/es.json
@@ -12,7 +12,7 @@
   "If you did not create an account, no further action is required.": "Si no ha creado una cuenta, no se requiere ninguna acción adicional.",
   "If you did not receive the email": "Si no ha recibido el correo electrónico",
   "If you did not request a password reset, no further action is required.": "Si no ha solicitado el restablecimiento de contraseña, omita este correo electrónico.",
-  "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser: [:actionURL](:actionURL)": "Si tiene problemas para hacer clic en el botón \":actionText\", copie y pegue la siguiente URL \nen su navegador web: [:actionURL](:actionURL)",
+  "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser: [:displayableActionUrl](:actionURL)": "Si tiene problemas para hacer clic en el botón \":actionText\", copie y pegue la siguiente URL \nen su navegador web: [:displayableActionUrl](:actionURL)",
   "Invalid signature.": "Firma no válida.",
   "Login": "Entrar",
   "Logout": "Salir",


### PR DESCRIPTION
This translation didn't work after updating to Laravel 7.0.*
![error-email](https://user-images.githubusercontent.com/9275870/76043984-032f0d80-5f27-11ea-8cc7-3f95e163ae21.png)
 